### PR TITLE
Update lolicon api url to v1

### DIFF
--- a/ATRI/plugins/setu/modules/main_setu.py
+++ b/ATRI/plugins/setu/modules/main_setu.py
@@ -16,7 +16,7 @@ from ATRI.exceptions import RequestError
 from .data_source import Hso, SIZE_REDUCE, SetuData
 
 
-LOLICON_URL: str = "https://api.lolicon.app/setu/v1"
+LOLICON_URL: str = "https://api.lolicon.app/setu/v1/"
 PIXIV_URL: str = (
     "https://api.kyomotoi.moe/api/pixiv/search?mode=exact_match_for_tags&word="
 )

--- a/ATRI/plugins/setu/modules/main_setu.py
+++ b/ATRI/plugins/setu/modules/main_setu.py
@@ -16,7 +16,7 @@ from ATRI.exceptions import RequestError
 from .data_source import Hso, SIZE_REDUCE, SetuData
 
 
-LOLICON_URL: str = "https://api.lolicon.app/setu/"
+LOLICON_URL: str = "https://api.lolicon.app/setu/v1"
 PIXIV_URL: str = (
     "https://api.kyomotoi.moe/api/pixiv/search?mode=exact_match_for_tags&word="
 )


### PR DESCRIPTION
lolicon API有新版了，旧版还在可以暂时改成旧版，新版有一些高级搜寻功能，可以整合进去。