### PR TITLE
修复两处搜图问题

### DIFF
--- a/ATRI/plugins/saucenao/data_source.py
+++ b/ATRI/plugins/saucenao/data_source.py
@@ -55,7 +55,7 @@ class SaouceNao(Service):
 
                 _result = dict()
                 _result["similarity"] = sim
-                _result["index_name"] = data[i]["header"]["index_name"]
+                _result["index_name"] = data["header"]["index_name"]
                 _result["url"] = choice(data["data"].get("ext_urls", ["None"]))
                 result.append(_result)
 

--- a/ATRI/plugins/setu/data_source.py
+++ b/ATRI/plugins/setu/data_source.py
@@ -45,15 +45,15 @@ class Setu(Service):
         res = await request.get(url)
         data: dict = await res.json()
 
-        temp_data: dict = data.get("data", list())[0]
-        if not temp_data:
-            is_ok = False
-        is_ok = True
-
-        title = temp_data.get("title", "木陰のねこ")
-        p_id = temp_data.get("pid", 88124144)
-        url = temp_data["urls"].get("original", "ignore")
-        setu = MessageSegment.image(url, timeout=114514)
+        try :
+            temp_data: dict = data.get("data", list())[0]
+            is_ok = True
+            title = temp_data.get("title", "木陰のねこ")
+            p_id = temp_data.get("pid", 88124144)
+            url = temp_data["urls"].get("original", "ignore")
+            setu = MessageSegment.image(url, timeout=114514)
+        except :
+            setu,title,p_id,is_ok = None,None,None,False
         return setu, title, p_id, is_ok
 
     @staticmethod


### PR DESCRIPTION
* 修复按tag搜索涩图时，如果tag不存在则出现list index out of range报错的问题
* 修复saucenao搜图出现KeyError的问题

下附报错：
```
Track ID：******
Prompt: Unknown ERROR->IndexError
Time: 2021-09-05 07:51:27
Traceback (most recent call last):
  File "/home/***/ATRI/ATRI/exceptions.py", line 103, in _track_error
    raise exception
  File "/home/***/.local/lib/python3.9/site-packages/nonebot/message.py", line 155, in _run_matcher
    await matcher.run(bot, event, state)
  File "/home/***/.local/lib/python3.9/site-packages/nonebot/matcher.py", line 584, in run
    await handler(self, bot, event, self.state)
  File "/home/***/.local/lib/python3.9/site-packages/nonebot/handler.py", line 81, in __call__
    await self.func(
  File "/home/***/ATRI/ATRI/plugins/setu/__init__.py", line 53, in _tag_setu
    setu, title, p_id, is_ok = await Setu().tag_setu(tag)
  File "/home/***/ATRI/ATRI/plugins/setu/data_source.py", line 48, in tag_setu
    temp_data: dict = data.get("data", list())[0]
IndexError: list index out of range
```
```
Track ID：******
Prompt: Unknown ERROR->KeyError
Time: 2021-09-05 07:37:51
Traceback (most recent call last):
  File "/home/***/ATRI/ATRI/exceptions.py", line 103, in _track_error
    raise exception
  File "/home/***/.local/lib/python3.9/site-packages/nonebot/message.py", line 155, in _run_matcher
    await matcher.run(bot, event, state)
  File "/home/***/.local/lib/python3.9/site-packages/nonebot/matcher.py", line 584, in run
    await handler(self, bot, event, self.state)
  File "/home/***/.local/lib/python3.9/site-packages/nonebot/handler.py", line 81, in __call__
    await self.func(
  File "/home/***/.local/lib/python3.9/site-packages/nonebot/matcher.py", line 467, in wrapper
    await func_handler(matcher, bot, event, state)
  File "/home/***/.local/lib/python3.9/site-packages/nonebot/handler.py", line 81, in __call__
    await self.func(
  File "/home/***/ATRI/ATRI/plugins/saucenao/__init__.py", line 52, in _deal_search
    result = f"> {MessageSegment.at(user_id)}" + await a.search(img[0])
  File "/home/***/ATRI/ATRI/plugins/saucenao/data_source.py", line 58, in search
    _result["index_name"] = data[i]["header"]["index_name"]
KeyError: 0
```

附：测试使用的系统环境：
* Archlinux
* python 3.9.6
* go-cqhttp v1.0.0 beta6