### PR TITLE
优化服务列表输出 & 去除scheduler Warning & 补充requirements.txt 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,5 +139,8 @@ dmypy.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python
 
+# for JetBrain Pycharm
+.idea
+
 /accounts/*
 /data/*

--- a/ATRI/plugins/help/data_source.py
+++ b/ATRI/plugins/help/data_source.py
@@ -1,11 +1,13 @@
 import os
+import json
+
+from tabulate import tabulate
 
 from ATRI import __version__
 from ATRI.rule import to_bot
 from ATRI.service import Service, SERVICES_DIR, ServiceTools
 from ATRI.config import BotSelfConfig
 from ATRI.exceptions import ReadFileError
-
 
 SERVICE_INFO_FORMAT = """
 服务名：{service}
@@ -14,7 +16,6 @@ SERVICE_INFO_FORMAT = """
 是否全局启用：{enabled}
 Tip: @bot 帮助 [服务] [命令] 以查看对应命令详细信息
 """.strip()
-
 
 COMMAND_INFO_FORMAT = """
 命令：{cmd}
@@ -56,13 +57,15 @@ class Helper(Service):
     @staticmethod
     def service_list() -> str:
         files = os.listdir(SERVICES_DIR)
-        temp_list = list()
-        for i in files:
-            service = i.replace(".json", "")
-            temp_list.append(service)
-
-        services = "、".join(map(str, temp_list))
-        repo = f"咱搭载了以下服务~\n{services}\n@bot 帮助 [服务] -以查看对应服务帮助"
+        services = list()
+        for f in files:
+            prefix = f.replace(".json", "")
+            f = os.path.join(SERVICES_DIR, f)
+            with open(f, "r", encoding="utf-8") as r:
+                service = json.load(r)
+                services.append([prefix, "√" if service["enabled"] else "×", "√" if service["only_admin"] else "×"])
+        table = tabulate(services, headers=["服务名称", "开启状态", "仅支持管理员"], tablefmt="plain", showindex=True)
+        repo = f"咱搭载了以下服务~\n{table}\n@bot 帮助 [服务] -以查看对应服务帮助"
         return repo
 
     @staticmethod

--- a/ATRI/utils/apscheduler.py
+++ b/ATRI/utils/apscheduler.py
@@ -9,16 +9,16 @@ from nonebot.log import logger, LoguruHandler
 
 
 apscheduler_autostart: bool = True
-apscheduler_config: dict = {"apscheduler.timezone": "Asia/Shanghai"}
+# apscheduler_config: dict = {"apscheduler.timezone": "Asia/Shanghai"}
 
 
 driver = get_driver()
-scheduler = AsyncIOScheduler()
+scheduler = AsyncIOScheduler(timezone="Asia/Shanghai")
 
 
 async def _start_scheduler():
     if not scheduler.running:
-        scheduler.configure(apscheduler_config)
+        # scheduler.configure(apscheduler_config)
         scheduler.start()
         logger.info("Scheduler Started.")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,6 @@ pyyaml>=5.4
 scikit-image>=0.18.3
 tensorflow>=2.6.0
 jieba>=0.42.1
+tabulate>=0.8.9
+wcwidth>=0.2.5
+aiohttp>=3.8.1

--- a/test/test_plugin_help.py
+++ b/test/test_plugin_help.py
@@ -66,17 +66,22 @@ async def test_about_me(app: App):
 @pytest.mark.asyncio
 async def test_service_list(app: App):
     import os
+    import json
+    from tabulate import tabulate
 
     from ATRI.service import SERVICES_DIR
     from ATRI.plugins.help import service_list
 
     files = os.listdir(SERVICES_DIR)
-    temp_list = list()
-    for i in files:
-        service = i.replace(".json", "")
-        temp_list.append(service)
-
-    services = "、".join(map(str, temp_list))
+    services = list()
+    for f in files:
+        prefix = f.replace(".json", "")
+        f = os.path.join(SERVICES_DIR, f)
+        with open(f, "r", encoding="utf-8") as r:
+            service = json.load(r)
+            services.append([prefix, "√" if service["enabled"] else "×", "√" if service["only_admin"] else "×"])
+    table = tabulate(services, headers=["服务名称", "开启状态", "仅支持管理员"], tablefmt="plain", showindex=True)
+    output = f"咱搭载了以下服务~\n{table}\n@bot 帮助 [服务] -以查看对应服务帮助"
 
     Message = make_fake_message()
 
@@ -91,7 +96,7 @@ async def test_service_list(app: App):
             event,
             f"""
             咱搭载了以下服务~
-            {services}
+            {output}
             @bot 帮助 [服务] -以查看对应服务帮助
             """,
             True,


### PR DESCRIPTION
偶尔看到的项目，感觉写的很不错，代码风格很棒，可读性很好。环境是在mac下做的，稍微做一点点小改进吧～
1. mac环境下install requirements没有自动安装aiohttp
2. 优化服务列表的输出，显示被禁用/admin only的服务详情；用了tabulate库提高机器人输出可读性（但是CJK的字体问题会导致有一些不对齐的现象，这个问题比较难解决）
3. 消除启动时的[PytzUsageWarning: The zone attribute is specific to pytz's interface; please migrate to a new time zone provider](参考：https://stackoverflow.com/questions/69776414/pytzusagewarning-the-zone-attribute-is-specific-to-pytzs-interface-please-mig)
4. .gitignore更新，排除.idea文件夹