### PR TITLE
Request Fix

### DIFF
--- a/ATRI/config.py
+++ b/ATRI/config.py
@@ -28,7 +28,7 @@ class BotSelfConfig:
         seconds=config.get("session_expire_timeout", 60)
     )
     proxy: str = config.get("proxy", None)
-    request_timeout = config.get("timeout", None)
+    request_timeout = config.get("request_timeout", None)
 
 
 class InlineGoCQHTTP:

--- a/ATRI/config.py
+++ b/ATRI/config.py
@@ -28,6 +28,7 @@ class BotSelfConfig:
         seconds=config.get("session_expire_timeout", 60)
     )
     proxy: str = config.get("proxy", None)
+    request_timeout = config.get("timeout", None)
 
 
 class InlineGoCQHTTP:

--- a/ATRI/plugins/anime_search.py
+++ b/ATRI/plugins/anime_search.py
@@ -9,7 +9,7 @@ from ATRI.utils import request, Translate
 from ATRI.exceptions import RequestError
 
 
-URL = "https://api.trace.moe/search?anilistInfo=true&url="
+URL = "https://api.trace.moe/search?anilistInfo=true"
 _anime_flmt_notice = choice(["慢...慢一..点❤", "冷静1下", "歇会歇会~~"])
 
 
@@ -21,9 +21,10 @@ class Anime(Service):
 
     @staticmethod
     async def _request(url: str) -> dict:
-        aim = URL + url
         try:
-            res = await request.get(aim)
+            resp = await request.get(url)
+            image_bytes = resp.read()
+            res = await request.post(URL, data=image_bytes,  headers={"Content-Type": "image/jpeg"})
         except Exception:
             raise RequestError("Request failed!")
         result = res.json()

--- a/ATRI/utils/request.py
+++ b/ATRI/utils/request.py
@@ -3,6 +3,9 @@ import httpx
 from ATRI.config import BotSelfConfig
 from ATRI.log import logger as log
 
+timeout = BotSelfConfig.request_timeout
+if timeout:
+    timeout = httpx.Timeout(timeout)
 
 if not BotSelfConfig.proxy:
     proxy = dict()
@@ -12,11 +15,11 @@ else:
 
 async def get(url: str, **kwargs):
     log.debug(f"GET {url} by {proxy if proxy else 'No proxy'} | MORE: \n {kwargs}")
-    async with httpx.AsyncClient(proxies=proxy) as client:  # type: ignore
+    async with httpx.AsyncClient(proxies=proxy, timeout=timeout) as client:  # type: ignore
         return await client.get(url, **kwargs)
 
 
 async def post(url: str, **kwargs):
     log.debug(f"POST {url} by {proxy if proxy else 'No proxy'} | MORE: \n {kwargs}")
-    async with httpx.AsyncClient(proxies=proxy) as client:  # type: ignore
+    async with httpx.AsyncClient(proxies=proxy, timeout=timeout) as client:  # type: ignore
         return await client.post(url, **kwargs)

--- a/config.yml
+++ b/config.yml
@@ -8,6 +8,7 @@ BotSelfConfig:
   command_sep: ["."]
   session_expire_timeout: 60
   proxy: ""  # 请参考文档
+  request_timeout: 5
 
 InlineGoCQHTTP:
   enabled: true


### PR DESCRIPTION
发现了两个问题
`httpx`有默认的超时设置，有的API请求比较久，可能还没返回就报错了，在config里配置；
`api.trace.moe`接受qq的图片url，获取到的图片是不对的，可以去网页上试试，改为上传图片数据后API正常。