### PR TITLE
Some suggestions

### DIFF
--- a/ATRI/exceptions.py
+++ b/ATRI/exceptions.py
@@ -45,7 +45,7 @@ def load_error(track_id: str) -> dict:
     return json.loads(path.read_bytes())
 
 
-class BaseBotException(BaseException):
+class BaseBotException(Exception):
     prompt: Optional[str] = "ignore"
 
     def __init__(self, prompt: Optional[str]) -> None:

--- a/ATRI/plugins/__init__.py
+++ b/ATRI/plugins/__init__.py
@@ -1,0 +1,43 @@
+from ATRI.database import init_database, close_database_connection
+from ATRI.utils.check_update import CheckUpdate
+from ATRI.log import logger as log
+from ATRI.utils.apscheduler import scheduler
+import ATRI
+
+from time import sleep
+
+driver = ATRI.driver()
+
+
+@driver.on_startup
+async def startup():
+    await init_database()
+
+    log.info(f"Now running: {ATRI.__version__}")
+
+    log.info("Starting to check update...")
+    commit_info = await CheckUpdate.show_latest_commit_info()
+    if commit_info:
+        log.info(commit_info)
+
+    l_v, l_v_t = await CheckUpdate.show_latest_version()
+    if l_v and l_v_t:
+        if l_v != ATRI.__version__:
+            log.warning("新版本已发布, 请更新.")
+            log.warning(f"最新版本: {l_v} 更新时间: {l_v_t}")
+            sleep(3)
+
+    if not scheduler.running:
+        scheduler.start()
+        log.info("Scheduler Started.")
+
+    log.info("アトリは、高性能ですから！")
+
+
+@driver.on_shutdown
+async def shutdown():
+    await close_database_connection()
+
+    scheduler.shutdown(False)
+
+    log.info("Thanks for using.")


### PR DESCRIPTION
- Can we make BaseBotException inherited from `Exception`?
With `BaseException`, nonebot won't catch and display exceptions like
`raise ThesaurusError(f"添加词库(tal)数据失败 目标词id: {_id}")`. They simply swallow it, that's quite confusing.
- Can we move database startup to `plugins/__init__.py`. Sometimes I just load one plugin to test it, if it needs database access,
it fails because `plugins/essential.py` is not imported
- I took care of plain-text message recall (will send it to superadmin), if this is the intended behavior?