### PR TITLE
修正go_cqhttp的下载域名

### DIFF
--- a/ATRI/configs/config.py
+++ b/ATRI/configs/config.py
@@ -61,7 +61,7 @@ class Config:
             command_sep=bot_conf.command_sep,
             session_expire_timeout=bot_conf.session_expire_timeout,
             gocq_accounts=gocq_conf.accounts,
-            gocq_download_domain=gocq_conf.download_version,
+            gocq_download_domain=gocq_conf.download_domain,
             gocq_version=gocq_conf.download_version,
             gocq_webui_username=gocq_conf.gocq_webui_username,
             gocq_webui_password=gocq_conf.gocq_webui_password,


### PR DESCRIPTION
当前的下载域名误填写为了下载版本，在config.py中进行了修正